### PR TITLE
Fix permissions problems

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -10,8 +10,10 @@ depend: [PureChat, PurePerms]
 commands:
  tag:
   description: Open tags UI
+  permission: tags.use
  givetag:
   description: Give someone a specific or random tag
+  permission: tags.give
 
 permissions:
  tags.use:

--- a/src/Itzdvbravo/Tags/TagManager.php
+++ b/src/Itzdvbravo/Tags/TagManager.php
@@ -90,7 +90,7 @@ class TagManager extends PluginBase{
     public function onCommand(CommandSender $player, Command $cmd, string $label, array $args): bool{
         switch ($cmd->getName()){
             case "tag":
-                if ($player->hasPermission("tag.use")) {
+                if ($player->hasPermission("tags.use")) {
                     if ($player instanceof Player) {
                         $this->openForm($player);
                     } else {


### PR DESCRIPTION
This update fixes permission based errors where players would get a message about not having correct perms to use a command, even if the permission node was set properly.

Fixes #2 